### PR TITLE
Reset Active Run included

### DIFF
--- a/backend/running/tests/test_views.py
+++ b/backend/running/tests/test_views.py
@@ -221,6 +221,14 @@ def test_end_active_run(auth_client, start_active_run, route: Route):
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 @pytest.mark.django_db
+def test_reset_active_run(auth_client, start_active_run):
+    response, data, url = start_active_run
+    response = auth_client.delete(url)
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    response = auth_client.get(url)
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+@pytest.mark.django_db
 def test_chart_data(auth_client, user, route: Route):
     url = reverse('chart')
     

--- a/backend/running/views.py
+++ b/backend/running/views.py
@@ -116,7 +116,7 @@ class PersonalBestView(generics.RetrieveAPIView):
 class ActiveRunView(generics.RetrieveUpdateAPIView):
     permission_classes = [IsAuthenticated]
     authentication_classes = [TokenAuthentication]
-    http_method_names = ['get', 'post', 'patch']
+    http_method_names = ['get', 'post', 'patch', 'delete']
 
     def get_object(self):
         """Returns an active (start has begun, but not complete) run for the current user"""
@@ -175,6 +175,13 @@ class ActiveRunView(generics.RetrieveUpdateAPIView):
         else:
             return GetRunningSerializer
 
+    def delete(self, request, *args, **kwargs):
+        """Delete the active run if it exists"""
+        instance = self.get_object()
+        if not instance:
+            return Response({"detail": "No active run currently."},status=status.HTTP_404_NOT_FOUND)
+        instance.delete()
+        return Response({"detail": "Active run has been removed."}, status=status.HTTP_204_NO_CONTENT)
 
 class ChartView(generics.ListAPIView):
     permission_classes = [IsAuthenticated]


### PR DESCRIPTION
Added functionality for the front-end to reset/end an Active Run without saving it as a completed run.
- DELETE endpoint for `api/run/active` 
- Unit test added.